### PR TITLE
Update interests: Replace Engineering with Shiba Inu

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -38,7 +38,7 @@
         <div class="tags">
           <span class="tag">🏛️ Temples &amp; Shrines</span>
           <span class="tag">🍜 Ramen</span>
-          <span class="tag">💻 Engineering</span>
+          <span class="tag">🐕 Shiba Inu</span>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
Updated the interests/tags displayed in the About section of the site layout to reflect current preferences.

## Changes
- Replaced "💻 Engineering" tag with "🐕 Shiba Inu" tag in the About section

## Details
This change updates the personal interests displayed on the site's default layout. The Engineering tag has been swapped out for a Shiba Inu tag, which will now appear alongside the existing Temples & Shrines and Ramen interests.
